### PR TITLE
Add model dsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ pkg/*
 Gemfile.lock
 tmp
 .env
+.rbenv
+.ruby-version
+coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ appreciated. The following details what you need to know in order to contribute.
 
 1. Read the project README before starting.
 1. Fork and clone the `main` branch of this repository locally.
-2. `cp .env.sample .env`
-3. Ensure there are no local setup, usage, and/or test issues.
-4. Add tests for new functionality and ensure they pass.
-5. Submit a pull request, follow the instructions provided, and ensure the build passes.
+1. [Setup](https://github.com/enerfip/gdpr-ruby#development)
+2. Ensure there are no local setup, usage, and/or test issues.
+3. Add tests for new functionality and ensure they pass.
+4. Submit a pull request, follow the instructions provided, and ensure the build passes.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ class Gdpr::Model::User
   end
 end
 
-# app/models/gdpr/model/settings.rb
-class Gdpr::Model::Settings
+# app/models/gdpr/model/user/settings.rb
+class Gdpr::Model::User::Settings
   include Gdpr::ModelDsl
 
   # TODO implementation

--- a/README.md
+++ b/README.md
@@ -38,17 +38,12 @@
 ## TODO
 
 Boilerplate
-- [ ] test DB + User model + assocations (belongs_to, has_many)
 - [ ] Do we really need a `config.ru` file for a Rack app???
 - [ ] Remove Thor from gemspec & cli ?
 
 Refactorings
 - [ ] Split core logic + DSL and make it independant from Rails. Add core-ext if `activesupport` is not defined. Use [dry constantize](https://rubydoc.info/gems/dry-inflector/Dry/Inflector#constantize-instance_method)
 
-DSL
-```ruby
-
-```
 ## Installing
 
 ### Rails application
@@ -63,7 +58,6 @@ DSL
 * Run `rails generate gdpr User` *Coming soon!*
 * Run `rspec spec/models/gdpr_linter_spec.rb` and update your gdpr definitions until linter is green.
 
-
 ### Configuration
 
 *Coming soon!*
@@ -72,57 +66,87 @@ DSL
 
 ### DSL
 
-gdpr-ruby DSL mimics ActiveRecord's DSL so you can mirror easily your data model with Gdpr definitions.
+`gdpr-ruby` DSL mimics ActiveRecord's DSL so you can mirror easily your data model with matching GDPR definitions.
 
-To use DSL, include it in your Gdpr definition classes, example:
+By convention, all attributes and associations of a model dealing with personal data should be defined in a matching GDPR model class, inside `Gdpr::Model` namespace. To use the DSL, simply include `Gdpr::ModelDsl`.
+For example, GDPR personal data for a  `User` model will be defined in a a `Gdpr::Model::User` class.
 
 ```rb
 module Gdpr::Model:::User
-  include Gdpr::ModeDsl
+  include Gdpr::ModelDsl
 
   personal do
-     # defining personal attributes here
+     # define personal data here
   end
- 
+
   non_personal do
-     # defining non personal attributes here (they are never exported nor anonymized)
+     # define non personal data here (never exported nor anonymized)
   end
 end
 ```
 
-All attributes and associations of any model handling personal data will have its Gdpr definition class, namespaced `Gdpr::Model`.
-So if you have a `User` model, you will need to create a `Gdpr::Model::User` class including the `Gdpr::ModelDsl` module.
-
-And EVERY field and association MUST appear in either the `Gdpr::Model::User`'s `personal` or `non_personal` block.
-Yes, the initial boilerplate may be painful, but this guarantees that no field will be forgotten when adding it to your schema.
+Please note that EVERY attribute and association must appear in either the `personal` or `non_personal` block.
+Initial boilerplate might be time consuming, but this guarantees that no attribute will be forgotten when the data model further evolves.
 
 `Gdpr::ModelDsl` provides the following class methods:
 
-* `personal` and `non_personal`, both methods accept a block without arguments.
-* `attributes`: any regular attribute except: foreign keys, files, jsonb attributes can be specified here
-* `file`: each attribute that stores a file path must be specified with this method. Currently only Carrierwave is supported
-* `hash`: json/jsonb data can be declared with this method, and you can specify a schema-less class to define Gdpr data inside this attribute.
-* `has_many`, `has_one` and `belongs_to`: to declare associations (will infer foreign key from your ORM - only ActiveRecord supported for now)
+* `personal` and `non_personal`, both methods accept a block without an argument.
+* `attributes` for any regular attribute except foreign keys, files and jsonb attributes.
+* `file` for attributes storing a file path. Currently only [CarrierWave](https://github.com/carrierwaveuploader/carrierwave) is supported.
+* `hash` for json/jsonb data. You can specify a schema-less class to define GDPR data inside this attribute.
+* `has_many`, `has_one` and `belongs_to` to declare associations. Iit will infer foreign key from your ORM. Only ActiveRecord is supported for now.
 
 #### Example Model Definition
 
 ```rb
+# schema.rb
+ActiveRecord::Schema.define do
+  create_table(:users, :force => true) do |t|
+    t.string :name
+    t.string :email
+    t.datetime :last_sign_in_at
+    t.string :last_sign_in_ip
+    t.string :encrypted_password
+    t.string :profile_picture
+    t.jsonb :settings, default: {}
+    t.timestamps
+  end
 
-class User < ApplicationRecord; end
+  create_table(:comments, :force => true) do |t|
+    t.string :name
+    t.integer :user_id
+    t.timestamps
+  end
+end
 
+# app/models/user.rb
+class User < ApplicationRecord
+  mount_uploader :profile_picture, FileUploader
+
+  has_many :comments
+end
+
+# app/models/gdpr/model/user.rb
 class Gdpr::Model::User
   include Gdpr::ModelDsl
 
   personal do
     attributes :email, :last_sign_in_ip, :last_signed_in_at
     file :profile_picture
-    has_many :comments  
-    hash :settings, class: Gdpr::Model::User::Settings
+    has_many :comments
+    hash :settings, class: Gdpr::Model::Settings
   end
 
   non_personal do
     attributes :id, :created_at, :updated_at, :encrypted_password
   end
+end
+
+# app/models/gdpr/model/settings.rb
+class Gdpr::Model::Settings
+  include Gdpr::ModelDsl
+
+  # TODO implementation
 end
 ```
 

--- a/lib/gdpr.rb
+++ b/lib/gdpr.rb
@@ -2,3 +2,4 @@
 
 require "gdpr/identity"
 require "gdpr/cli"
+require "gdpr/model_dsl"

--- a/lib/gdpr/model_dsl.rb
+++ b/lib/gdpr/model_dsl.rb
@@ -1,0 +1,155 @@
+module Gdpr
+  module ModelDsl
+    def self.included(kls)
+      kls.extend ClassMethods
+    end
+
+    module ClassMethods
+      def personal(&block)
+        with_options(type: :personal, &block)
+      end
+
+      def non_personal(&block)
+        with_options(type: :non_personal, &block)
+      end
+
+      def file(field, driver: nil, type:)
+        if type == :personal
+          raise "File driver is required for personal files" if driver.blank?
+          personal_file(field, driver: driver)
+        else
+          non_personal_file(field)
+        end
+      end
+
+      def attributes(*fields, type:)
+        public_send("#{type}_attributes", *fields)
+      end
+
+      def hash(field, model: nil, type:)
+        if type == :personal
+          personal_hash(field, model: model)
+        else
+          non_personal_hash(field)
+        end
+      end
+
+      def has_many(field, model: nil, type:)
+        if type == :personal
+          personal_has_many(field, model: model)
+        else
+          non_personal_has_many(field)
+        end
+      end
+
+      def has_one(field, model: nil, type:)
+        if type == :personal
+          personal_has_one(field, model: model)
+        else
+          non_personal_has_one(field)
+        end
+      end
+
+      def belongs_to(field, model: nil, type:)
+        if type == :personal
+          personal_belongs_to(field, model: model)
+        else
+          non_personal_belongs_to(field)
+        end
+      end
+
+      def personal_attributes(*fields)
+        @personal_attributes ||= []
+        @personal_attributes += fields if fields.any?
+        @personal_attributes
+      end
+
+      def non_personal_attributes(*fields)
+        @non_personal_attributes ||= []
+        @non_personal_attributes += fields if fields.any?
+        @non_personal_attributes
+      end
+
+      def personal_file(file = nil, driver: nil)
+        personal_files << [file, driver] if file.present?
+        personal_files
+      end
+
+      def non_personal_file(file = nil)
+        non_personal_files << file
+      end
+
+      def personal_files
+        @personal_files ||= []
+      end
+
+      def non_personal_files
+        @non_personal_files ||= []
+      end
+
+      def personal_hash(field, model:)
+        personal_hashes << [field, model]
+      end
+
+      def non_personal_hash(field)
+        non_personal_hashes << field
+      end
+
+      def personal_hashes
+        @personal_hashes ||= []
+      end
+
+      def non_personal_hashes
+        @non_personal_hashes ||= []
+      end
+
+      def personal_has_many(association, model:)
+        personal_has_manies << [association, model]
+      end
+
+      def personal_has_manies
+        @personal_has_manies ||= []
+      end
+
+      def non_personal_has_many(association)
+        non_personal_has_manies << association
+      end
+
+      def non_personal_has_manies
+        @non_personal_has_manies ||= []
+      end
+
+      def personal_has_one(association, model:)
+        personal_has_ones << [association, model]
+      end
+
+      def personal_has_ones
+        @personal_has_ones ||= []
+      end
+
+      def non_personal_has_one(association)
+        non_personal_has_ones << association
+      end
+
+      def non_personal_has_ones
+        @non_personal_has_ones ||= []
+      end
+
+      def personal_belongs_to(association, model:)
+        personal_belongs_tos << [association, model]
+      end
+
+      def personal_belongs_tos
+        @personal_belongs_tos ||= []
+      end
+
+      def non_personal_belongs_to(association)
+        non_personal_belongs_tos << association
+      end
+
+      def non_personal_belongs_tos
+        @non_personal_belongs_tos ||= []
+      end
+    end
+  end
+end

--- a/spec/lib/gdpr/model_dsl_spec.rb
+++ b/spec/lib/gdpr/model_dsl_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.describe Gdpr::ModelDsl do
+  module Gdpr::Model
+    class DummyUser; end
+    class DummyAsset; end
+  end
+
+  class DummyUser
+    include Gdpr::ModelDsl
+    personal do
+      attributes :email, :name
+      has_many :friends, model: "Gdpr::Model::DummyUser"
+      has_one :best_friend, model: "Gdpr::Model::DummyUser"
+      belongs_to :father, model: "Gdpr::Model::DummyUser"
+      file :document, driver: :carrierwave
+    end
+
+    non_personal do
+      attributes :remember_token
+      has_many :assets
+      has_one :car
+      belongs_to :building
+      file :avatar
+    end
+  end
+
+  it "stores definitions correctly" do
+    expect(DummyUser.personal_attributes).to eq [:email, :name]
+    expect(DummyUser.personal_has_manies).to eq [[:friends, "Gdpr::Model::DummyUser"]]
+    expect(DummyUser.personal_has_ones).to eq [[:best_friend, "Gdpr::Model::DummyUser"]]
+    expect(DummyUser.personal_belongs_tos).to eq [[:father, "Gdpr::Model::DummyUser"]]
+    expect(DummyUser.non_personal_has_manies).to eq [:assets]
+    expect(DummyUser.non_personal_has_ones).to eq [:car]
+    expect(DummyUser.non_personal_belongs_tos).to eq [:building]
+    expect(DummyUser.personal_hashes).to eq []
+    expect(DummyUser.non_personal_hashes).to eq []
+    expect(DummyUser.personal_files).to eq [[:document, :carrierwave]]
+    expect(DummyUser.non_personal_files).to eq [:avatar]
+  end
+end


### PR DESCRIPTION
Model DSL is first brick of rgpd-ruby core.

This DSL is available as a module that can be included in any model definition class.

e.g.

```rb
module Gdpr::Model:::User
  include Gdpr::ModeDsl

  personal do
     # defining personal attributes here
  end
 
  non_personal do
     # defining non personal attributes here (they are never exported nor anonymized)
  end
end
```

